### PR TITLE
♻️ Refactor: s3 파일 전체 조회 + 도로명 주소 파싱하여 응답바디 추가

### DIFF
--- a/src/main/java/com/practice/likelionhackathoncesco/domain/analysisreport/controller/AnalysisReportController.java
+++ b/src/main/java/com/practice/likelionhackathoncesco/domain/analysisreport/controller/AnalysisReportController.java
@@ -1,17 +1,18 @@
 package com.practice.likelionhackathoncesco.domain.analysisreport.controller;
 
 import com.practice.likelionhackathoncesco.domain.analysisreport.dto.response.FileUploadResponse;
-import com.practice.likelionhackathoncesco.domain.analysisreport.entity.AnalysisReport;
 import com.practice.likelionhackathoncesco.domain.analysisreport.entity.PathName;
 import com.practice.likelionhackathoncesco.domain.analysisreport.service.AnalysisReportService;
 import com.practice.likelionhackathoncesco.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,6 +48,17 @@ public class AnalysisReportController {
     Boolean result = analysisReportService.deleteReport(reportId);
 
     return ResponseEntity.ok(BaseResponse.success("파일이 삭제되었습니다.", result));
+  }
+
+  @Operation(summary = "업로드한 등기부등본 전체 조회 API", description = "마이페이지에서 사용자가 업로드한 등기부등본을 모두 조회하는 API")
+  @GetMapping("/get-file")
+  public ResponseEntity<BaseResponse<List<String>>> getAllFile() {
+
+    log.info("S3에 업로드한 모든 등기부등본 파일 조회");
+
+    List<String> s3files = analysisReportService.getAllS3Files(PathName.PROPERTYREGISTRY);
+
+    return ResponseEntity.ok(BaseResponse.success("조회 성공", s3files));
   }
 
 }

--- a/src/main/java/com/practice/likelionhackathoncesco/domain/analysisreport/entity/AnalysisReport.java
+++ b/src/main/java/com/practice/likelionhackathoncesco/domain/analysisreport/entity/AnalysisReport.java
@@ -39,11 +39,6 @@ public class AnalysisReport extends BaseTimeEntity {
   private String s3Key; // s3 객체 식별 키
   // s3 경로 -> 추후에 s3key로 객체 url(웹 형태) 생성 (동적 생성 가능)
 
-  // 분석 결과 관련
-/*  @Lob
-  @Column(name = "ocr_text")
-  private String ocrText; // 추출된 텍스트 저장*/
-
   @Column(name = "safety_score")
   private Double safetyScore; // 안전 점수
 

--- a/src/main/java/com/practice/likelionhackathoncesco/domain/analysisreport/service/AnalysisReportService.java
+++ b/src/main/java/com/practice/likelionhackathoncesco/domain/analysisreport/service/AnalysisReportService.java
@@ -157,27 +157,6 @@ public class AnalysisReportService {
     return filename.substring(filename.lastIndexOf("."));
   }
 
-  // 업로드한 파일 목록 전체 조회
-  public List<String> getAllFiles(PathName pathName) {
-    String prefix = switch (pathName) {
-      case PROPERTYREGISTRY ->s3Config.getDocumentsPath(); // 버킷 내 등기부등본 폴더구조 선택
-      case FRAUD -> s3Config.getFraudPath(); // 버킷 내 신고 관련 폴더구조 선택
-    };
-
-    try {
-      return amazonS3
-          .listObjectsV2(
-              new ListObjectsV2Request().withBucketName(s3Config.getBucket()).withPrefix(prefix))
-          .getObjectSummaries()
-          .stream()
-          .map(obj -> amazonS3.getUrl(s3Config.getBucket(), obj.getKey()).toString())
-          .collect(Collectors.toList());
-    } catch (Exception e) {
-      log.error("S3 파일 목록 조회 중 오류 발생", e);
-      throw new CustomException(AnalysisReportErrorCode.FILE_SERVER_ERROR);
-    }
-  }
-
   // 파일이 s3에 존재하는지 s3key 값으로 확인
   private void existFile(String keyName) {
     if (!amazonS3.doesObjectExist(s3Config.getBucket(), keyName)) {

--- a/src/main/java/com/practice/likelionhackathoncesco/naverocr/dto/response/OcrResponse.java
+++ b/src/main/java/com/practice/likelionhackathoncesco/naverocr/dto/response/OcrResponse.java
@@ -18,6 +18,8 @@ public class OcrResponse {
   @Schema(description = "추출된 텍스트", example = ".")
   private Map<String, List<String>> sections;
 
+  @Schema(description = "표제부의 도로명 주소", example = ".")
+  private RoadAddress roadAddress;
 
   @Schema(description = "진행 상태", example = "OCR_COMPLETED")
   private ProcessingStatus processingStatus;

--- a/src/main/java/com/practice/likelionhackathoncesco/naverocr/dto/response/RoadAddress.java
+++ b/src/main/java/com/practice/likelionhackathoncesco/naverocr/dto/response/RoadAddress.java
@@ -1,0 +1,27 @@
+package com.practice.likelionhackathoncesco.naverocr.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class RoadAddress {
+
+  @Schema(description = "시도", example = "서울특별시")
+  private String sido;
+
+  @Schema(description = "시군구", example = "서초구")
+  private String sigungu;
+
+  @Schema(description = "도로명", example = "서초대로")
+  private String roadName;
+
+  @Schema(description = "건물번호", example = "219")
+  private String buildingNumber;
+
+}

--- a/src/main/java/com/practice/likelionhackathoncesco/naverocr/service/NaverOcrService.java
+++ b/src/main/java/com/practice/likelionhackathoncesco/naverocr/service/NaverOcrService.java
@@ -70,9 +70,6 @@ public class NaverOcrService {
 
         log.info("OCR 처리 완료: reportId={}", reportId);
 
-      /*// 추출된 텍스트 DB에 저장
-      analysisReport.updateOcrText(ocrResult.getSections().toString()); // toString()으로 저장*/
-
         // DB에 진행 상태 필드 업데이트
         analysisReport.updateProcessingStatus(ProcessingStatus.OCR_COMPLETED);
         analysisReportRepository.save(analysisReport);

--- a/src/main/java/com/practice/likelionhackathoncesco/naverocr/service/NaverOcrService.java
+++ b/src/main/java/com/practice/likelionhackathoncesco/naverocr/service/NaverOcrService.java
@@ -13,6 +13,7 @@ import com.practice.likelionhackathoncesco.global.exception.CustomException;
 import com.practice.likelionhackathoncesco.naverocr.dto.ImageDto;
 import com.practice.likelionhackathoncesco.naverocr.dto.request.OcrRequest;
 import com.practice.likelionhackathoncesco.naverocr.dto.response.OcrResponse;
+import com.practice.likelionhackathoncesco.naverocr.dto.response.RoadAddress;
 import com.practice.likelionhackathoncesco.naverocr.global.config.NaverOcrConfig;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,7 +25,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -77,10 +77,7 @@ public class NaverOcrService {
         analysisReport.updateProcessingStatus(ProcessingStatus.OCR_COMPLETED);
         analysisReportRepository.save(analysisReport);
 
-        return OcrResponse.builder()
-            .sections(ocrResult.getSections())
-            .processingStatus(ProcessingStatus.OCR_COMPLETED)
-            .build();
+        return ocrResult;
 
       } catch (CustomException e) {
         throw new CustomException(S3ErrorCode.FILE_DOWNLOAD_FAIL);
@@ -184,6 +181,7 @@ public class NaverOcrService {
 
     Map<String, List<String>> result = new LinkedHashMap<>(); // 표제부, 갑구, 을구 순서 보장
     List<String> fallbackNames = List.of("표제부", "갑구", "을구");
+    RoadAddress roadAddress = null; // 도로명주소 객체
 
     // 응답 바디의 image 배열의 첫번째 요소(ocr한 첫 페이지)의 table(표)를 가져옴
     JsonNode tablesNode = root
@@ -224,13 +222,80 @@ public class NaverOcrService {
         }
 
         result.put(sectionName, inferTexts);
+
+        if ("표제부".equals(sectionName)) {
+          roadAddress = extractRoadAddress(inferTexts);
+        }
       }
     }
     return OcrResponse.builder()
         .sections(result)
+        .roadAddress(roadAddress)
         .processingStatus(ProcessingStatus.OCR_COMPLETED)
         .build();
 
+  }
+
+  private RoadAddress extractRoadAddress(List<String> inferTexts) {
+    log.info("도로명주소 추출 시작, 총 텍스트 개수: {}", inferTexts.size());
+
+    int roadAddressIndex = -1;
+    for (int i = 0; i < inferTexts.size(); i++) {
+      String text = inferTexts.get(i).trim();
+      log.info("검사중인 텍스트: '{}'", text);
+
+      // 여러 패턴으로 매칭 시도
+      if (text.contains("도로명주소") ||
+          text.contains("[도로명주소]") ||
+          text.equals("[도로명주소]")) {
+        roadAddressIndex = i;
+        log.info("도로명주소 키워드 발견! 인덱스: {}, 텍스트: '{}'", i, text);
+        break;
+      }
+    }
+
+    if (roadAddressIndex == -1) {
+      log.warn("도로명주소 키워드를 찾을 수 없습니다");
+      return null; // 도로명주소를 찾을 수 없음
+    }
+
+    try {
+      // 인덱스 범위 체크
+      if (roadAddressIndex + 4 >= inferTexts.size()) {
+        log.warn("도로명주소 다음 요소들이 부족합니다. 필요: {}, 실제: {}",
+            roadAddressIndex + 4, inferTexts.size() - 1);
+        return null;
+      }
+
+      // [도로명주소] 다음 4개 요소가 시도, 시군구, 도로명, 건물번호
+      String sido = inferTexts.get(roadAddressIndex + 1).trim();
+      String sigungu = inferTexts.get(roadAddressIndex + 2).trim();
+      String roadName = inferTexts.get(roadAddressIndex + 3).trim();
+      String buildingNumber = inferTexts.get(roadAddressIndex + 4).trim();
+
+      log.info("추출된 도로명주소 정보 - 시도: '{}', 시군구: '{}', 도로명: '{}', 건물번호: '{}'",
+          sido, sigungu, roadName, buildingNumber);
+
+      // 빈 값 체크
+      if (sido.isEmpty() || sigungu.isEmpty() || roadName.isEmpty() || buildingNumber.isEmpty()) {
+        log.warn("도로명주소 정보 중 빈 값이 있습니다");
+        return null;
+      }
+
+      RoadAddress result = RoadAddress.builder()
+          .sido(sido)
+          .sigungu(sigungu)
+          .roadName(roadName)
+          .buildingNumber(buildingNumber)
+          .build();
+
+      log.info("도로명주소 추출 성공: {}", result);
+      return result;
+
+    } catch (IndexOutOfBoundsException e) {
+      // 도로명주소 정보가 불완전한 경우
+      return null;
+    }
   }
 
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#22 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 마이페이지에 업로드한 등기부등본 파일 원본 조회를 위한 url 반환
- ocr로 추출한 텍스트에서 표제부에 나와있는 도로명 주소를 따로 파싱하여 응답바디에 추가함
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).